### PR TITLE
Update hive to use kerberos authentication

### DIFF
--- a/wmfdata/hive.py
+++ b/wmfdata/hive.py
@@ -22,7 +22,10 @@ def run(cmds, fmt = "pandas"):
     result = None
     
     try:
-        hive_conn = impala_conn(host='an-coord1001.eqiad.wmnet', port=10000, auth_mechanism='PLAIN')
+        hive_conn = impala_conn(host='an-coord1001.eqiad.wmnet',
+                                port=10000,
+                                auth_mechanism='GSSAPI',
+                                kerberos_service_name='hive')
         hive_cursor = hive_conn.cursor()
         
         for cmd in cmds:


### PR DESCRIPTION
Changes the parameters used to connect to Hive so that it uses
kerberos for authentication. Tested and works for me on notebook1003, but you should verify it.