### PR TITLE
Check update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 .vscode/
+wmfdata/__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,2 @@
-# wmfdata 0.1.1
-
-- Added `check_remote_version()` in `utils` module.
-- Added a check of remote version on import and a notification that an update is available.
-
-# wmfdata 0.1.0
-
-- Added CHANGELOG.md to keep track of changes that come with every new version.
+# Next
+- Notify users about newer releases when package is imported 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# wmfdata 0.1.1
+
+- Added `check_remote_version()` in `utils` module.
+- Added a check of remote version on import and a notification that an update is available.
+
 # wmfdata 0.1.0
 
 - Added CHANGELOG.md to keep track of changes that come with every new version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# wmfdata 0.1.0
+
+- Added CHANGELOG.md to keep track of changes that come with every new version.

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 
 setup(
     name="wmfdata",
-    version="0.1",
+    version="0.1.0",
     description="Tools for analyzing data on SWAP, a platform for confidential Wikimedia data",
     install_requires=[
         "impyla",
         "matplotlib>=2.1", # 2.1 introducted ticker.PercentFormatter
-        "mysql-connector-python", 
+        "mysql-connector-python",
         "pandas",
         "thrift-sasl==0.2.1" # impyla can't connect properly to Hive with a later version
     ],

--- a/setup.py
+++ b/setup.py
@@ -7,14 +7,12 @@ setup(
     version=__version__,
     description="Tools for analyzing data on SWAP, a platform for confidential Wikimedia data",
     install_requires=[
-        "findspark",
         "impyla",
         "IPython",
         "matplotlib>=2.1",  # 2.1 introduced ticker.PercentFormatter
         "mysql-connector-python",
         "pandas",
         "packaging",
-        "pyspark",
         "requests",
         "thrift-sasl==0.2.1",  # impyla can't connect properly to Hive with a later version
     ],

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,16 @@ setup(
     version=__version__,
     description="Tools for analyzing data on SWAP, a platform for confidential Wikimedia data",
     install_requires=[
+        "findspark",
         "impyla",
-        "matplotlib>=2.1",  # 2.1 introducted ticker.PercentFormatter
+        "IPython",
+        "matplotlib>=2.1",  # 2.1 introduced ticker.PercentFormatter
         "mysql-connector-python",
         "pandas",
+        "packaging",
+        "pyspark",
         "requests",
-        "thrift-sasl==0.2.1"  # impyla can't connect properly to Hive with a later version
+        "thrift-sasl==0.2.1",  # impyla can't connect properly to Hive with a later version
     ],
     packages=find_packages(),
     python_requires=">=3"

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,18 @@
 from setuptools import setup, find_packages
 
+from wmfdata import __version__
+
 setup(
     name="wmfdata",
-    version="0.1.0",
+    version=__version__,
     description="Tools for analyzing data on SWAP, a platform for confidential Wikimedia data",
     install_requires=[
         "impyla",
-        "matplotlib>=2.1", # 2.1 introducted ticker.PercentFormatter
+        "matplotlib>=2.1",  # 2.1 introducted ticker.PercentFormatter
         "mysql-connector-python",
         "pandas",
-        "thrift-sasl==0.2.1" # impyla can't connect properly to Hive with a later version
+        "requests",
+        "thrift-sasl==0.2.1"  # impyla can't connect properly to Hive with a later version
     ],
     packages=find_packages(),
     python_requires=">=3"

--- a/wmfdata/__init__.py
+++ b/wmfdata/__init__.py
@@ -1,5 +1,10 @@
-# Import all submodules so all are accessible after `import wmfdata`
-from wmfdata import charting, hive, utils # mariadb,
+__version__ = "0.1.0"
+__source__ = "https://github.com/neilpquinn/wmfdata"
 
-# Direct reusers to package
-utils.print_err("You can find the source for `wmfdata` at https://github.com/neilpquinn/wmfdata")
+# Import all submodules so all are accessible after `import wmfdata`
+from wmfdata import charting, hive, utils  # mariadb,
+
+welcome_message = "You are using wmfdata version {0}. You can find the source for `wmfdata` at {1}"
+welcome_message.format(__version__, __source__)
+
+utils.print_err(welcome_message)

--- a/wmfdata/__init__.py
+++ b/wmfdata/__init__.py
@@ -17,7 +17,7 @@ if remote['is_newer']:
     """
     update_message = update_message.format(__version__, remote['version'], url_extra)
 else:
-    update_message = "You are using the latest version of wmfdata (v{0}).".format(__version__)
+    update_message = "You are using version {0} of wmfdata (latest).".format(__version__)
 
 welcome_message = welcome_message.format(update_message, __source__)
 utils.print_err(welcome_message)

--- a/wmfdata/__init__.py
+++ b/wmfdata/__init__.py
@@ -1,10 +1,27 @@
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __source__ = "https://github.com/neilpquinn/wmfdata"
 
 # Import all submodules so all are accessible after `import wmfdata`
 from wmfdata import charting, hive, utils  # mariadb,
 
-welcome_message = "You are using wmfdata version {0}. You can find the source for `wmfdata` at {1}"
-welcome_message.format(__version__, __source__)
+welcome_message = """
+{0}
+
+You can find the source for `wmfdata` at {1}
+"""
+
+branch = "check-update"
+remote = utils.check_remote_version(__version__, branch)
+if remote['is_newer']:
+    url_extra = "" if branch == "master" else "@{0}".format(branch)
+    update_message = """
+    You are using wmfdata version {0}. A newer version ({1}) is available.
+    Update via: pip install --upgrade git+https://github.com/neilpquinn/wmfdata.git{2}
+    """
+    update_message = update_message.format(__version__, remote['version'], url_extra)
+else:
+    update_message = "You are using the latest version of wmfdata (v{0}).".format(__version__)
+
+welcome_message.format(update_message, __source__)
 
 utils.print_err(welcome_message)

--- a/wmfdata/__init__.py
+++ b/wmfdata/__init__.py
@@ -8,7 +8,7 @@ welcome_message = """{0}
 
 You can find the source for `wmfdata` at {1}"""
 
-branch = "check-update"  # change to "master" once in production
+branch = "master"
 remote = utils.check_remote_version(__version__, branch)
 if remote['is_newer']:
     url_extra = "" if branch == "master" else "@{0}".format(branch)

--- a/wmfdata/__init__.py
+++ b/wmfdata/__init__.py
@@ -8,14 +8,13 @@ welcome_message = """{0}
 
 You can find the source for `wmfdata` at {1}"""
 
-branch = "check-update"
+branch = "check-update"  # change to "master" once in production
 remote = utils.check_remote_version(__version__, branch)
 if remote['is_newer']:
     url_extra = "" if branch == "master" else "@{0}".format(branch)
     update_message = """You are using wmfdata version {0}. A newer version is available.
-    Update to version {1} via: pip install --upgrade git+https://github.com/neilpquinn/wmfdata.git{2}
-    """
-    update_message = update_message.format(__version__, remote['version'], url_extra)
+Update to version {1} via: pip install --upgrade git+{2}/wmfdata.git{3}"""
+    update_message = update_message.format(__version__, remote['version'], __source__, url_extra)
 else:
     update_message = "You are using version {0} of wmfdata (latest).".format(__version__)
 

--- a/wmfdata/__init__.py
+++ b/wmfdata/__init__.py
@@ -8,15 +8,14 @@ welcome_message = """{0}
 
 You can find the source for `wmfdata` at {1}"""
 
-branch = "master"
-remote = utils.check_remote_version(__version__, branch)
+remote = utils.check_remote_version(__version__)
 if remote['is_newer']:
-    url_extra = "" if branch == "master" else "@{0}".format(branch)
-    update_message = """You are using wmfdata version {0}. A newer version is available.
-Update to version {1} via: pip install --upgrade git+{2}/wmfdata.git{3}"""
-    update_message = update_message.format(__version__, remote['version'], __source__, url_extra)
+    update_message = """You are using wmfdata {0}. A newer version is available.
+Update to {1} via: pip install --upgrade git+{2}/wmfdata.git
+To see what changed refer to https://github.com/neilpquinn/wmfdata/CHANGELOG.md"""
+    update_message = update_message.format(__version__, remote['version'], __source__)
 else:
-    update_message = "You are using version {0} of wmfdata (latest).".format(__version__)
+    update_message = "You are using wmfdata {0} (latest).".format(__version__)
 
 welcome_message = welcome_message.format(update_message, __source__)
 utils.print_err(welcome_message)

--- a/wmfdata/__init__.py
+++ b/wmfdata/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1"
+__version__ = "0.1.0"
 __source__ = "https://github.com/neilpquinn/wmfdata"
 
 # Import all submodules so all are accessible after `import wmfdata`

--- a/wmfdata/__init__.py
+++ b/wmfdata/__init__.py
@@ -11,8 +11,8 @@ You can find the source for `wmfdata` at {1}"""
 remote = utils.check_remote_version(__version__)
 if remote['is_newer']:
     update_message = """You are using wmfdata {0}. A newer version is available.
-Update to {1} via: pip install --upgrade git+{2}/wmfdata.git
-To see what changed refer to https://github.com/neilpquinn/wmfdata/CHANGELOG.md"""
+You can update to {1} by running `pip install --upgrade git+{2}/wmfdata.git@release`
+To see what has changed, refer to https://github.com/neilpquinn/wmfdata/CHANGELOG.md"""
     update_message = update_message.format(__version__, remote['version'], __source__)
 else:
     update_message = "You are using wmfdata {0} (latest).".format(__version__)

--- a/wmfdata/__init__.py
+++ b/wmfdata/__init__.py
@@ -4,24 +4,20 @@ __source__ = "https://github.com/neilpquinn/wmfdata"
 # Import all submodules so all are accessible after `import wmfdata`
 from wmfdata import charting, hive, utils  # mariadb,
 
-welcome_message = """
-{0}
+welcome_message = """{0}
 
-You can find the source for `wmfdata` at {1}
-"""
+You can find the source for `wmfdata` at {1}"""
 
 branch = "check-update"
 remote = utils.check_remote_version(__version__, branch)
 if remote['is_newer']:
     url_extra = "" if branch == "master" else "@{0}".format(branch)
-    update_message = """
-    You are using wmfdata version {0}. A newer version ({1}) is available.
-    Update via: pip install --upgrade git+https://github.com/neilpquinn/wmfdata.git{2}
+    update_message = """You are using wmfdata version {0}. A newer version is available.
+    Update to version {1} via: pip install --upgrade git+https://github.com/neilpquinn/wmfdata.git{2}
     """
     update_message = update_message.format(__version__, remote['version'], url_extra)
 else:
     update_message = "You are using the latest version of wmfdata (v{0}).".format(__version__)
 
-welcome_message.format(update_message, __source__)
-
+welcome_message = welcome_message.format(update_message, __source__)
 utils.print_err(welcome_message)

--- a/wmfdata/utils.py
+++ b/wmfdata/utils.py
@@ -1,10 +1,11 @@
 import sys
 from math import log10, floor
 import re
+import requests
+from packaging import version
 
 from IPython.display import HTML
 import pandas as pd
-
 
 def print_err(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
@@ -93,3 +94,14 @@ def df_to_remarkup(df):
     remarkup_table = remarkup_table.replace("\n", "\n" + header_sep + "\n", 1)
     
     print(remarkup_table)
+
+def check_remote_version(local_version, remote_branch="master"):
+    url = "https://raw.githubusercontent.com/neilpquinn/wmfdata/{0}/wmfdata/__init__.py"
+    url = url.format(remote_branch)
+    r = requests.get(url)
+    remote_version = re.search('(([0-9]+\\.?){2,3})', r.text.split("\n")[0]).group(0)
+    d = {
+        'version': remote_version,
+        'is_newer': version.parse(remote_version) > version.parse(local_version)
+    }
+    return d

--- a/wmfdata/utils.py
+++ b/wmfdata/utils.py
@@ -95,9 +95,8 @@ def df_to_remarkup(df):
     
     print(remarkup_table)
 
-def check_remote_version(local_version, remote_branch="master"):
-    url = "https://raw.githubusercontent.com/neilpquinn/wmfdata/{0}/wmfdata/__init__.py"
-    url = url.format(remote_branch)
+def check_remote_version(local_version):
+    url = "https://raw.githubusercontent.com/neilpquinn/wmfdata/release/wmfdata/__init__.py"
     r = requests.get(url)
     remote_version = re.search('(([0-9]+\\.?){2,3})', r.text.split("\n")[0]).group(0)
     d = {


### PR DESCRIPTION
While I was reading Marshall's comment in [T240890#5772652](https://phabricator.wikimedia.org/T240890#5772652) it occurred to me that wmfdata may sometimes be updated in a major way (e.g. to support a new environment) and that the end user may not remember to occasionally upgrade the local install, especially if they don't see any update announcements.

To that end, I propose this logic for comparing the local version of the package with the remote version on `import wmfdata`. If the remote version is newer, the user sees a message like:

```
You are using wmfdata 0.1.0. A newer version is available.
Update to 0.1.1 via: pip install --upgrade git+https://github.com/neilpquinn/wmfdata/wmfdata.git
To see what changed refer to https://github.com/neilpquinn/wmfdata/CHANGELOG.md

You can find the source for `wmfdata` at https://github.com/neilpquinn/wmfdata
```

**Topic for discussion**: ability to suppress this check by defining & exporting an environmental variable in ~/.bashrc or ~/.bash_profile. Then `__init__.py` checks if the variable is defined and only performs the check if it's not.