### PR TITLE
Correct update message URL

### DIFF
--- a/wmfdata/__init__.py
+++ b/wmfdata/__init__.py
@@ -8,7 +8,7 @@ try:
     if remote['is_newer']:
         update_message = (
             "You are using wmfdata v{0}, but v{1} is available.\n\n" +
-            "To update, run `pip install --upgrade git+{2}/wmfdata.git@release`.\n\n" +
+            "To update, run `pip install --upgrade git+{2}.git@release`.\n\n" +
             "To see the changes, refer to {2}/blob/release/CHANGELOG.md"
         ).format(metadata.version, remote['version'], metadata.source)
         utils.print_err(update_message)


### PR DESCRIPTION
The update message lists a repo URL that results in an error when using it to upgrade:

```(venv) nettrom@notebook1004:~/src$ pip install --upgrade git+https://github.com/neilpquinn/wmfdata/wmfdata.git@release
Collecting git+https://github.com/neilpquinn/wmfdata/wmfdata.git@release
  Cloning https://github.com/neilpquinn/wmfdata/wmfdata.git (to revision release) to /tmp/pip-req-build-8vc82m69
  Running command git clone -q https://github.com/neilpquinn/wmfdata/wmfdata.git /tmp/pip-req-build-8vc82m69
  remote: Not Found
  fatal: repository 'https://nettrom@github.com/neilpquinn/wmfdata/wmfdata.git/' not found
```

This pull request updates `update_message` so the URL it outputs matches the one in the README file, which works.
