### PR TITLE
Timeout remote version checking

### DIFF
--- a/wmfdata/utils.py
+++ b/wmfdata/utils.py
@@ -107,7 +107,7 @@ def df_to_remarkup(df):
     print(remarkup_table)
 
 def check_remote_version(source_url, local_version):
-    r = requests.get(source_url + "/raw/release/wmfdata/metadata.py")
+    r = requests.get(source_url + "/raw/release/wmfdata/metadata.py", timeout=1)
     # Raise an error if the page couldn't be loaded
     r.raise_for_status()
 


### PR DESCRIPTION
In places where this remote checking can't work, like restricted
networks, it will attempt until the connection is closed, which can take
minutes.  In the vast majority of cases it shouldn't take more than 1
second, so setting that timeout to let it fail fast in those cases.