### PR TITLE
Add spark support for shipping conda environments and DRY http proxy setting propagation

### DIFF
--- a/wmfdata/__init__.py
+++ b/wmfdata/__init__.py
@@ -1,6 +1,6 @@
 # Import all submodules so they are accessible after `import wmfdata`. utils must go
-# first to prevent circular import issues. Other submodules can depend on utils ONLY.
-from wmfdata import utils
+# first to prevent circular import issues. Other submodules can depend on utils and/or conda ONLY.
+from wmfdata import utils, conda
 from wmfdata import (
     charting,
     hive,

--- a/wmfdata/conda.py
+++ b/wmfdata/conda.py
@@ -8,22 +8,22 @@ try:
 except ImportError:
     conda_installed = False
 
-from wmfdata.utils import log
+from wmfdata.utils import print_err
 
 """
 Default CONDA_BASE_ENV_PREFIX.
 """
-conda_base_env_prefix_default = '/usr/lib/anaconda-wmf'
+conda_base_env_prefix_default = "/usr/lib/anaconda-wmf"
 
 """
 Default kwargs to pass to conda_pack.pack.
 """
 conda_pack_defaults = {
     # This is required to pack stacked conda envs.
-    'ignore_editable_packages': True,
-    'verbose': True,
-    'force': False,
-    'format': 'tgz',
+    "ignore_editable_packages": True,
+    "verbose": True,
+    "force": False,
+    "format": "tgz",
 }
 
 def info():
@@ -31,7 +31,7 @@ def info():
     Returns the result of conda info --all --json as a dict.
     """
     if conda_installed:
-        return json.loads(condacli('info', ["--all", "--json"])[0])
+        return json.loads(condacli("info", ["--all", "--json"])[0])
     else:
         return {}
 
@@ -39,26 +39,26 @@ def env_vars():
     """
     Returns dict of conda environment variables.
     """
-    return info().get('env_vars', {})
+    return info().get("env_vars", {})
 
 def active_prefix():
     """
     Returns the path to the active conda env, or None.
     """
-    return info().get('active_prefix', None)
+    return info().get("active_prefix", None)
 
 def active_name():
     """
     Returns the name of the active conda env, or None.
     """
-    return env_vars().get('CONDA_DEFAULT_ENV', None)
+    return env_vars().get("CONDA_DEFAULT_ENV", None)
 
 def base_prefix():
     """
     If the active conda env is stacked on another conda env, returns
     the path to that base conda env, or None.
     """
-    return env_vars().get('CONDA_PREFIX_1', None)
+    return env_vars().get("CONDA_PREFIX_1", None)
 
 def is_active():
     """
@@ -84,14 +84,14 @@ def conda_base_env_prefix():
     Returns the path to the conda base env, which on WMF servers is /usr/lib/anaconda-wmf.
     This can be overridden by setting the CONDA_BASE_ENV_PREFIX env var.
     """
-    return os.environ.get('CONDA_BASE_ENV_PREFIX', conda_base_env_prefix_default)
+    return os.environ.get("CONDA_BASE_ENV_PREFIX", conda_base_env_prefix_default)
 
 
 def pack(**conda_pack_kwargs):
     """
     Calls conda_pack.pack.
     If the packed output file already exists, this will not repackage
-    it unless conda_pack_kwargs['force'] == True.
+    it unless conda_pack_kwargs["force"] == True.
 
     Returns the path to the output packed env file.
 
@@ -102,30 +102,30 @@ def pack(**conda_pack_kwargs):
     kwargs.update(conda_pack_kwargs)
 
     # Make sure output is set to something, so we can return it if it already exists.
-    if 'output' not in kwargs:
-        conda_env_name = 'env'
-        if 'prefix' in kwargs:
-            conda_env_name = os.path.basename(kwargs['prefix'])
-        elif 'name' in kwargs:
-            conda_env_name = kwargs['name']
+    if "output" not in kwargs:
+        conda_env_name = "env"
+        if "prefix" in kwargs:
+            conda_env_name = os.path.basename(kwargs["prefix"])
+        elif "name" in kwargs:
+            conda_env_name = kwargs["name"]
         elif is_active():
             conda_env_name = active_name()
 
-        kwargs['output'] = 'conda-{}.{}'.format(conda_env_name, kwargs['format'])
+        kwargs["output"] = "conda-{}.{}".format(conda_env_name, kwargs["format"])
 
-    conda_packed_file = kwargs['output']
-    if os.path.isfile(conda_packed_file) and not kwargs['force']:
-        log.info(
-            f'A conda environment is already packed at {conda_packed_file}. '
-            'If you have recently installed new packages into your conda env, set '
-            'force=True in conda_pack_kwargs and it will be repacked for you.'
+    conda_packed_file = kwargs["output"]
+    if os.path.isfile(conda_packed_file) and not kwargs["force"]:
+        print_err(
+            f"A conda environment is already packed at {conda_packed_file}. "
+            "If you have recently installed new packages into your conda env, set "
+            "force=True in conda_pack_kwargs and it will be repacked for you."
         )
         return conda_packed_file
     else:
-        # Isolate the import here so that we don't get import errors
+        # Isolate the import here so that we don"t get import errors
         # if conda_pack is not installed (e.g. in a virtualenv).
         import conda_pack
         # NOTE: If no conda env is currently active, and kwargs
-        # doesn't contain information about what env to pack (i.e. no name or prefix)
+        # doesn"t contain information about what env to pack (i.e. no name or prefix)
         # then this raise an error.
         return conda_pack.pack(**kwargs)

--- a/wmfdata/conda.py
+++ b/wmfdata/conda.py
@@ -1,0 +1,131 @@
+import json
+import os
+
+# In case conda is not installed, we still want these functions to return something useful.
+try:
+    from conda.cli.python_api import run_command as condacli
+    conda_installed = True
+except ImportError:
+    conda_installed = False
+
+from wmfdata.utils import log
+
+"""
+Default CONDA_BASE_ENV_PREFIX.
+"""
+conda_base_env_prefix_default = '/usr/lib/anaconda-wmf'
+
+"""
+Default kwargs to pass to conda_pack.pack.
+"""
+conda_pack_defaults = {
+    # This is required to pack stacked conda envs.
+    'ignore_editable_packages': True,
+    'verbose': True,
+    'force': False,
+    'format': 'tgz',
+}
+
+def info():
+    """
+    Returns the result of conda info --all --json as a dict.
+    """
+    if conda_installed:
+        return json.loads(condacli('info', ["--all", "--json"])[0])
+    else:
+        return {}
+
+def env_vars():
+    """
+    Returns dict of conda environment variables.
+    """
+    return info().get('env_vars', {})
+
+def active_prefix():
+    """
+    Returns the path to the active conda env, or None.
+    """
+    return info().get('active_prefix', None)
+
+def active_name():
+    """
+    Returns the name of the active conda env, or None.
+    """
+    return env_vars().get('CONDA_DEFAULT_ENV', None)
+
+def base_prefix():
+    """
+    If the active conda env is stacked on another conda env, returns
+    the path to that base conda env, or None.
+    """
+    return env_vars().get('CONDA_PREFIX_1', None)
+
+def is_active():
+    """
+    Returns True if a conda env is active, else False.
+    """
+    if active_prefix() is None:
+        return False
+    else:
+        return True
+
+def is_stacked():
+    """
+    Returns True if a conda env active and stacked on a base conda env, else False.
+    """
+    if base_prefix() is None:
+        return False
+    else:
+        return True
+
+
+def conda_base_env_prefix():
+    """
+    Returns the path to the conda base env, which on WMF servers is /usr/lib/anaconda-wmf.
+    This can be overridden by setting the CONDA_BASE_ENV_PREFIX env var.
+    """
+    return os.environ.get('CONDA_BASE_ENV_PREFIX', conda_base_env_prefix_default)
+
+
+def pack(**conda_pack_kwargs):
+    """
+    Calls conda_pack.pack.
+    If the packed output file already exists, this will not repackage
+    it unless conda_pack_kwargs['force'] == True.
+
+    Returns the path to the output packed env file.
+
+    Arguments:
+    * `conda_pack_kwargs` args to pass to conda_pack.pack().
+    """
+    kwargs = conda_pack_defaults.copy()
+    kwargs.update(conda_pack_kwargs)
+
+    # Make sure output is set to something, so we can return it if it already exists.
+    if 'output' not in kwargs:
+        conda_env_name = 'env'
+        if 'prefix' in kwargs:
+            conda_env_name = os.path.basename(kwargs['prefix'])
+        elif 'name' in kwargs:
+            conda_env_name = kwargs['name']
+        elif is_active():
+            conda_env_name = active_name()
+
+        kwargs['output'] = 'conda-{}.{}'.format(conda_env_name, kwargs['format'])
+
+    conda_packed_file = kwargs['output']
+    if os.path.isfile(conda_packed_file) and not kwargs['force']:
+        log.info(
+            f'A conda environment is already packed at {conda_packed_file}. '
+            'If you have recently installed new packages into your conda env, set '
+            'force=True in conda_pack_kwargs and it will be repacked for you.'
+        )
+        return conda_packed_file
+    else:
+        # Isolate the import here so that we don't get import errors
+        # if conda_pack is not installed (e.g. in a virtualenv).
+        import conda_pack
+        # NOTE: If no conda env is currently active, and kwargs
+        # doesn't contain information about what env to pack (i.e. no name or prefix)
+        # then this raise an error.
+        return conda_pack.pack(**kwargs)

--- a/wmfdata/spark.py
+++ b/wmfdata/spark.py
@@ -8,8 +8,8 @@ from wmfdata import conda
 from wmfdata.utils import (
     check_kerberos_auth,
     ensure_list,
-    python_version,
-    log
+    print_err,
+    python_version
 )
 
 """
@@ -68,8 +68,8 @@ def get_custom_session(
     master="local[2]",
     app_name="wmfdata-custom",
     spark_config={},
-    ship_python_env = False,
-    conda_pack_kwargs = {}
+    ship_python_env=False,
+    conda_pack_kwargs={}
 ):
     """
     Returns an existent SparkSession, or a new one if one hasn't yet been created.
@@ -115,7 +115,7 @@ def get_custom_session(
                 spark_config["spark.yarn.dist.archives"] += f",{conda_spark_archive}"
             else:
                 spark_config["spark.yarn.dist.archives"] = conda_spark_archive
-            log.info(f"Will ship {conda_packed_file} to remote Spark executors.")
+            print_err(f"Will ship {conda_packed_file} to remote Spark executors.")
 
             # Workers should use python from the unpacked conda env.
             os.environ["PYSPARK_PYTHON"] = f"{conda_packed_name}/bin/python3"
@@ -134,7 +134,7 @@ def get_custom_session(
             os.environ["PYSPARK_PYTHON"] = f"/usr/bin/python{python_version()}"
 
         if "PYSPARK_PYTHON" in os.environ:
-            log.info(
+            print_err(
                 "PySpark executors will use {}.".format(os.environ["PYSPARK_PYTHON"])
             )
 

--- a/wmfdata/spark.py
+++ b/wmfdata/spark.py
@@ -1,14 +1,21 @@
 from threading import Timer
 import warnings
+import os
 
 import findspark
-findspark.init("/usr/lib/spark2")
-from pyspark.sql import SparkSession
 
+from wmfdata import conda
 from wmfdata.utils import (
     check_kerberos_auth,
-    ensure_list
+    ensure_list,
+    python_version,
+    log
 )
+
+"""
+Will be used for findspark.init().
+"""
+SPARK_HOME = os.environ.get("SPARK_HOME", "/usr/lib/spark2")
 
 """
 Predefined spark sessions and configs for use with the get_session and run functions.
@@ -56,7 +63,9 @@ EXTRA_JAVA_OPTIONS = {
 def get_custom_session(
     master="local[2]",
     app_name="wmfdata-custom",
-    spark_config={}
+    spark_config={},
+    ship_python_env = False,
+    conda_pack_kwargs = {}
 ):
     """
     Returns an existent SparkSession, or a new one if one hasn't yet been created.
@@ -69,11 +78,72 @@ def get_custom_session(
 
     Arguments:
     * `master`: passed to SparkSession.builder.master()
+      If this is "yarn" and and a conda env is active and and ship_python_env=False,
+      remote executors will be configured to use conda.conda_base_env_prefix(),
+      which defaults to anaconda-wmf. This should usually work as anaconda-wmf
+      is installed on all WMF YARN worker nodes.  If your conda environment
+      has required packages installed that are not in anaconda-wmf, set
+      ship_python_env=True.
     * `app_name`: passed to SparkSession.builder.appName().
     * `spark_config`: passed to SparkSession.builder.config()
+    * `ship_python_env`: If master='yarn' and this is True, a conda env will be packed
+      and shipped to remote Spark executors.  This is useful if your conda env
+      has Python or other packages that the executors will need to do their work.
+    * `conda_pack_kwargs`: Args to pass to conda_pack.pack(). If none are given, this will
+      call conda_pack.pack() with no args, causing the default currently active
+      conda environment to be packed.
+      You can pack and ship any conda environment by setting appropriate args here.
+      See https://conda.github.io/conda-pack/api.html#pack
+      If True, this will fail if conda and conda_pack are not installed.
     """
+    if master == "yarn":
+        check_kerberos_auth()
 
-    check_kerberos_auth()
+        if ship_python_env:
+            # The path to our packed conda environment.
+            conda_packed_file = conda.pack(**conda_pack_kwargs)
+            # This will be used as the unpacked directory name in the YARN working directory.
+            conda_packed_name = os.path.splitext(os.path.basename(conda_packed_file))[0]
+
+            # Ship conda_packed_file to each YARN worker.
+            conda_spark_archive = f"{conda_packed_file}#{conda_packed_name}"
+            if "spark.yarn.dist.archives" in spark_config:
+                spark_config["spark.yarn.dist.archives"] += f",{conda_spark_archive}"
+            else:
+                spark_config["spark.yarn.dist.archives"] = conda_spark_archive
+            log.info(f"Will ship {conda_packed_file} to remote Spark executors.")
+
+            # Workers should use python from the unpacked conda env.
+            os.environ["PYSPARK_PYTHON"] = f"{conda_packed_name}/bin/python3"
+        # Else if conda is active, use the use the conda_base_env_prefix (anaconda-wmf)
+        # environment, as this should exist on all worker nodes.
+        elif conda.is_active():
+            os.environ["PYSPARK_PYTHON"] = os.path.join(
+                conda.conda_base_env_prefix(), "bin", "python3"
+            )
+        # Else use the system python.  We can't use any current conda or virtualenv python
+        # as these won't be present on the remote YARN workers.
+        # The python version workers should use must be the same as the currently
+        # running python version, so only set this if that version of python
+        # (e.g. python3.7) is installed in the system.
+        elif os.path.isfile(os.path.join(f"/usr/bin/python{python_version()}")):
+            os.environ["PYSPARK_PYTHON"] = f"/usr/bin/python{python_version()}"
+
+        if "PYSPARK_PYTHON" in os.environ:
+            log.info(
+                "PySpark executors will use {}.".format(os.environ["PYSPARK_PYTHON"])
+            )
+
+    # NOTE: We don't need to touch PYSPARK_PYTHON if master != yarn.
+    # The default set by findspark will be fine.
+
+    # Call findspark.init after PYSPARK_PYTHON has possibly been set.
+    # This is needed because findspark will set PYSPARK_PYTHON path
+    # to sys.executable if it isn't yet set, which will likely not
+    # work in YARN mode if sys.executlable is a local conda or virtualenv
+    # (as is the case in WMF Jupyter Notebooks).
+    findspark.init(SPARK_HOME)
+    from pyspark.sql import SparkSession
 
     # TODO: if there's an existing session, it will be returned with its
     # existing settings even if the user has specified a different set of
@@ -100,7 +170,8 @@ def get_custom_session(
 def get_session(
     type="yarn-regular",
     app_name=None,
-    extra_settings={}
+    extra_settings={},
+    ship_python_env=False,
 ):
     """
     Returns a Spark session based on one of the PREDEFINED_SPARK_SESSION types.
@@ -117,6 +188,9 @@ def get_session(
     * `extra_settings`: A dict of additional Spark configs to use when creating
       the Spark session. These will override the defaults specified
       by `type`.
+    * `ship_python_env`: If master='yarn' and this is True, a conda env will be packed
+      and shipped to remote Spark executors.  This is useful if your active conda env
+      has Python or other packages that the executors will need to do their work.
     """
 
     if type not in PREDEFINED_SPARK_SESSIONS.keys():
@@ -135,7 +209,8 @@ def get_session(
     return get_custom_session(
         master=PREDEFINED_SPARK_SESSIONS[type]["master"],
         app_name=app_name,
-        spark_config=config
+        spark_config=config,
+        ship_python_env=ship_python_env
     )
 
 

--- a/wmfdata/spark.py
+++ b/wmfdata/spark.py
@@ -100,9 +100,9 @@ def get_custom_session(
       See https://conda.github.io/conda-pack/api.html#pack
       If True, this will fail if conda and conda_pack are not installed.
     """
-    if master == "yarn":
-        check_kerberos_auth()
+    check_kerberos_auth()
 
+    if master == "yarn":
         if ship_python_env:
             # The path to our packed conda environment.
             conda_packed_file = conda.pack(**conda_pack_kwargs)

--- a/wmfdata/utils.py
+++ b/wmfdata/utils.py
@@ -1,3 +1,4 @@
+import logging
 from math import log10, floor
 import os.path
 import re
@@ -8,6 +9,19 @@ from IPython.display import HTML
 from packaging import version
 import pandas as pd
 import requests
+
+"""
+Global wmfdata.utils.log logger.  Usage:
+
+from wmfdata.utils import log
+log.info("my message")
+"""
+log = logging.getLogger('wmfdata')
+log.setLevel(logging.INFO)
+formatter = logging.Formatter(fmt='%(asctime)s %(levelname)s %(name)s: %(message)s', datefmt='%Y-%m-%dT%H:%M:%S')
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(formatter)
+log.addHandler(handler)
 
 def print_err(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
@@ -53,9 +67,9 @@ def insert_code_toggle():
           style="font-size: 1.4em"
         >
     </form>
-    
+
     <script>
-    code_shown = true; 
+    code_shown = true;
 
     function code_toggle() {
         if (code_shown) {
@@ -158,3 +172,11 @@ def get_dblist(dblist_name, dblist_path="/srv/mediawiki-config/dblists"):
     lines = map(str.strip, lines)
     lines = filter(lambda w: not w.startswith("#"), lines)
     return list(lines)
+
+def python_version():
+    """
+    Returns currently running python major.minor version. E.g "3.7"
+    """
+    return f"{sys.version_info.major}.{sys.version_info.minor}"
+
+

--- a/wmfdata/utils.py
+++ b/wmfdata/utils.py
@@ -10,19 +10,6 @@ from packaging import version
 import pandas as pd
 import requests
 
-"""
-Global wmfdata.utils.log logger.  Usage:
-
-from wmfdata.utils import log
-log.info("my message")
-"""
-log = logging.getLogger('wmfdata')
-log.setLevel(logging.INFO)
-formatter = logging.Formatter(fmt='%(asctime)s %(levelname)s %(name)s: %(message)s', datefmt='%Y-%m-%dT%H:%M:%S')
-handler = logging.StreamHandler(sys.stdout)
-handler.setFormatter(formatter)
-log.addHandler(handler)
-
 def print_err(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 


### PR DESCRIPTION
This helps automate shipping of conda environments
to remote YARN workers when there are dependencies
needed there that are not installed there by default.

This also properly sets up PYSPARK_PYTHON to use
anaconda-wmf on remote YARN workers if the user
chooses not to ship a conda environment of their own.
anaconda-wmf is installed everywhere and is a better default
for remote python than the system installed one.

Bug: T272313