### PR TITLE
Improve handling of nulls and blobs in binary fields

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -3,8 +3,9 @@ This document has useful instructions for people who are interested fixing bugs 
 ## Installing in development mode
 When you work on changes to this package, you will want an easily-accessible local copy that's at the top of your Python path. Here's the recommended way to do that:
 1. Clone this repository to whatever location you like.
-1. Install the cloned repository in [development mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html) using `pip install -e`.
+1. Install the cloned repository in [development mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html) using `pip install -e .`
     * This will end early with the message `ERROR: Could not install packages due to an OSError: [Errno 30] Read-only file system: 'WHEEL'`. This is okay; the crucial step has already been done.
+    * NOTE: In some cases, this can also give you `ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied...`.  In this case, you *should* follow the advice and pass `--user` as in `pip install --user -e .`
 1. Change to the `site-packages` directory for your current environment using the following command: `` cd `python -c "import sysconfig; print(sysconfig.get_path('purelib'))"` ``
 1. Edit the `anaconda.pth` file in that directory to include the absolute path (not using `~`) to the cloned repository.
     * This ensures the new version of Wmfdata is on your Python path (which `pip install -e` would have done if not for the error) _and_ ensures it takes precendence over the version of Wmfdata in the base `anaconda-wmf` environment.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "IPython",
         "findspark",
         "matplotlib>=2.1", # 2.1 introduced ticker.PercentFormatter
-        "mysql-connector-python",
+        "mysql-connector-python>=8.0.24", # 8.0.24 made major changes to value conversion
         "pandas>=0.20.1", # 0.20.1 introduced the errors module
         "packaging",
         "pyarrow",

--- a/wmfdata/mariadb.py
+++ b/wmfdata/mariadb.py
@@ -20,9 +20,19 @@ class BytesConverter(mysql.conversion.MySQLConverter):
     the MySQL library for possible conversion.
     """
     def to_python(self, vtype, value):
-        mysql_string_types = mysql.constants.FieldType.get_string_types()
-        if vtype[1] in mysql_string_types:
-            return value.decode('utf-8')
+        types_to_decode = (
+            # (VAR)CHAR, (VAR)BINARY, etc.
+            mysql.constants.FieldType.get_string_types()
+            # BLOB types
+            + mysql.constants.FieldType.get_binary_types()
+        )
+        if vtype[1] in types_to_decode:
+            try:
+                return value.decode('utf-8')
+            # This should only occur with NULLs and non-binary strings,
+            # which don't need conversion
+            except AttributeError:
+                return value
         else:
             return super().to_python(vtype, value)
 


### PR DESCRIPTION
Previously, a null value in a binary-encoded MariaDB field would cause an
AttributeError. These are rare in our infrastructure since MediaWiki generally
uses empty strings instead.

I had assumed that MediaWiki did not use blob fields, but it turns out they
are very common. In all the cases I found, the fields contain UTF-8 string
data, so these are now decoded as well.