### PR TITLE
Add function to format an SQL tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Next version
+* `utils` now includes an `sql_tuple` function which makes it easy to format a Python list or tuple for use in an SQL IN clause.
+
 # 1.3.3 (11 March 2022)
 * Improve handling of nulls and blobs in binary fields (#29)
 * Switch to pyhive as a hive interface (#24)

--- a/wmfdata/utils.py
+++ b/wmfdata/utils.py
@@ -166,4 +166,28 @@ def python_version():
     """
     return f"{sys.version_info.major}.{sys.version_info.minor}"
 
+def sql_tuple(i):
+    """
+    Given a Python iterable, returns a string representation that can be used in an SQL IN
+    clause.
 
+    For example:
+    > sql_tuple(["a", "b", "c"])
+    "('a', 'b', 'c')"
+    """
+    # It might seem useful to return "()" when an empty iterable is passed, but "IN ()"
+    # results in an SQL syntax error. Instead, we should send a clear signal to the caller
+    # that it needs to better handle the no-items case.
+    if len(i) == 0:
+        raise ValueError("Cannot produce an SQL tuple without any items.")
+
+    # Transform other iterables into lists, raising errors for non-iterables
+    if type(i) != list:
+        i = [x for x in i]
+
+    # Using Python's string representation functionality means we get escaping for free. Using the
+    # representation of a tuple almost works, but fails when there's just one element, because SQL
+    # doesn't accept the trailing comma that Python uses. Instead, we use representation of a
+    # list and replace the brackets with parentheses.
+    list_repr = repr(i)
+    return "(" + list_repr[1:-1] + ")"

--- a/wmfdata_tests/tests.py
+++ b/wmfdata_tests/tests.py
@@ -181,7 +181,7 @@ def test_sql_tuple():
         raise AssertionError("Passing an empty iterable to sql_tuple should raise a ValueError.")
 
     t = wmf.utils.sql_tuple(("enwiki", "arwiki", "dewiki"))
-    assert t = "('enwiki', 'arwiki', 'dewiki')"
+    assert t == "('enwiki', 'arwiki', 'dewiki')"
 
     log_test_passed("utils.sql_tuple unit test")
 

--- a/wmfdata_tests/tests.py
+++ b/wmfdata_tests/tests.py
@@ -171,6 +171,20 @@ def test_load_csv():
 
     log_test_passed("Load CSV to Data Lake")
 
+def test_sql_tuple():
+    try:
+        wmf.utils.sql_tuple([])
+    # We want a ValueError in this case
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Passing an empty iterable to sql_tuple should raise a ValueError.")
+
+    t = wmf.utils.sql_tuple(("enwiki", "arwiki", "dewiki"))
+    assert t = "('enwiki', 'arwiki', 'dewiki')"
+
+    log_test_passed("utils.sql_tuple unit test")
+
 
 def main():
     clean_tables()
@@ -185,6 +199,8 @@ def main():
     test_read_via_mariadb()
     test_silent_command_via_MariaDB()
     test_load_csv()
+
+    test_sql_tuple()
 
     clean_tables()
 


### PR DESCRIPTION
This is a useful convenience for analysts. For example, if you have a long list of users and you want to look up their user IDs, this lets you simply write:
```python
wmf.mariadb.run(f"""
SELECT
    user_name,
    user_id
FROM user
WHERE
    user_name IN {sql_tuple(users)}
""", "enwiki")
```