### PR TITLE
Default spark sessions to Spark3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Next version
+* Spark2 has been deprecated, and Spark sessions will now pick up Spark3 by default. Please see [T318367](https://phabricator.wikimedia.org/T318367) for documentation on how to migrate your jobs. If you still want to use Spark2, you can override the `SPARK_HOME` environment variable. In Python, overriding will look like so:
+```python
+# make sure to override at the top of your script!
+import os
+os.environ["SPARK_HOME"] = '/usr/lib/spark2'
+```
+
 # 1.4.0 (20 October 2022)
 * `mariadb.run` now uses the MariaDB Python connector library rather than the MySQL one, which fixes several errors ([T319360](https://phabricator.wikimedia.org/T319360)).
 * `utils` now includes an `sql_tuple` function which makes it easy to format a Python list or tuple for use in an SQL IN clause.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Next version
-* Spark2 has been deprecated, and Spark sessions will now pick up Spark3 by default. Please see [T318367](https://phabricator.wikimedia.org/T318367) for documentation on how to migrate your jobs. If you still want to use Spark2, you can override the `SPARK_HOME` environment variable. In Python, overriding will look like so:
-```python
-# make sure to override at the top of your script!
-import os
-os.environ["SPARK_HOME"] = '/usr/lib/spark2'
-```
+* Spark2 has been deprecated, and Spark sessions will now pick up Spark3 by default. Please see [T318367](https://phabricator.wikimedia.org/T318367) for documentation on how to migrate your jobs. See also instructions on how to override the Spark version on [Wikitech](https://wikitech.wikimedia.org/wiki/Analytics/Systems/Jupyter#Choosing_between_Spark3_and_Spark2).
 
 # 1.4.0 (20 October 2022)
 * `mariadb.run` now uses the MariaDB Python connector library rather than the MySQL one, which fixes several errors ([T319360](https://phabricator.wikimedia.org/T319360)).

--- a/wmfdata/spark.py
+++ b/wmfdata/spark.py
@@ -15,7 +15,13 @@ from wmfdata.utils import (
 """
 Will be used for findspark.init().
 """
-SPARK_HOME = os.environ.get("SPARK_HOME", "/usr/lib/spark2")
+SPARK_HOME = os.environ.get("SPARK_HOME", "/usr/lib/spark3")
+if SPARK_HOME == "/usr/lib/spark2":
+    warnings.warn(
+        "Spark2 has been deprecated. Please upgrade your jobs to Spark3. "
+        "See https://phabricator.wikimedia.org/T318367 for details.",
+        category=FutureWarning
+    )
 
 """
 Predefined spark sessions and configs for use with the get_session and run functions.


### PR DESCRIPTION
Simple changes that:
* Make Spark3 be the new default for Spark Sessions.
* Explains how to override back to Spark2.