### PR TITLE
Find conda when on a cloned conda-analytics env.

### DIFF
--- a/wmfdata/conda.py
+++ b/wmfdata/conda.py
@@ -1,19 +1,32 @@
 import json
 import os
-
-# In case conda is not installed, we still want these functions to return something useful.
-try:
-    from conda.cli.python_api import run_command as condacli
-    conda_installed = True
-except ImportError:
-    conda_installed = False
-
+import sys
 from wmfdata.utils import print_err
+
+
+# In case conda is not installed, we still want the functions below to return something useful.
+def __find_conda():
+    try:
+        from conda.cli.python_api import run_command as condacli
+        return True
+    except ImportError:
+        return False
+
+
+# first, try just importing. this should work for anaconda-wmf stacked environments
+conda_installed = __find_conda()
+# if not found, we may be on a conda-analytics cloned environment
+# conda clones do not include the conda package so we include a helper
+# symlink to conda python path when installing conda-analytics
+if not conda_installed and os.path.islink("/usr/lib/conda"):
+    sys.path.append("/usr/lib/conda")
+    conda_installed = __find_conda()
+
 
 """
 Default CONDA_BASE_ENV_PREFIX.
 """
-conda_base_env_prefix_default = "/usr/lib/anaconda-wmf"
+conda_base_env_prefix_default = "/opt/conda-analytics"
 
 """
 Default kwargs to pass to conda_pack.pack.
@@ -81,7 +94,7 @@ def is_stacked():
 
 def conda_base_env_prefix():
     """
-    Returns the path to the conda base env, which on WMF servers is /usr/lib/anaconda-wmf.
+    Returns the path to the conda base env, which on WMF servers is /opt/conda-analytics.
     This can be overridden by setting the CONDA_BASE_ENV_PREFIX env var.
     """
     return os.environ.get("CONDA_BASE_ENV_PREFIX", conda_base_env_prefix_default)

--- a/wmfdata/spark.py
+++ b/wmfdata/spark.py
@@ -90,9 +90,9 @@ def get_custom_session(
     * `master`: passed to SparkSession.builder.master()
       If this is "yarn" and and a conda env is active and and ship_python_env=False,
       remote executors will be configured to use conda.conda_base_env_prefix(),
-      which defaults to anaconda-wmf. This should usually work as anaconda-wmf
+      which defaults to conda-analytics. This should usually work as conda-analytics
       is installed on all WMF YARN worker nodes.  If your conda environment
-      has required packages installed that are not in anaconda-wmf, set
+      has required packages installed that are not in conda-analytics, set
       ship_python_env=True.
     * `app_name`: passed to SparkSession.builder.appName().
     * `spark_config`: passed to SparkSession.builder.config()
@@ -125,7 +125,7 @@ def get_custom_session(
 
             # Workers should use python from the unpacked conda env.
             os.environ["PYSPARK_PYTHON"] = f"{conda_packed_name}/bin/python3"
-        # Else if conda is active, use the use the conda_base_env_prefix (anaconda-wmf)
+        # Else if conda is active, use the conda_base_env_prefix (conda-analytics)
         # environment, as this should exist on all worker nodes.
         elif conda.is_active():
             os.environ["PYSPARK_PYTHON"] = os.path.join(


### PR DESCRIPTION
On the new `conda-analytics` conda environment, we do not have the conda package available.

This is because when doing `conda create --clone ...` conda explicitly removes conda related packages. I presume the rationale is that only the base should typically include the `conda` package. This was never an issue on `anaconda-wmf` since that environment was using the `--stacked` flag.

In this PR we thus modify the `sys.path` to find conda on the base environment, if we detect that we are running on top of `conda-analytics`.