### PR TITLE
Use new method to set Pandas's display.max_colwidth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ setup(
         # This is the latest version which supports MariaDB Connector/C 3.1.16,
         # which is the version currently available on the analytics clients
         "mariadb==1.0.11",
-        "pandas>=0.20.1", # 0.20.1 introduced the errors module
+        # Pandas 1.0 is the the first to support None as a value for
+        # `display.max_colwidth`
+        # https://github.com/pandas-dev/pandas/issues/31532
+        "pandas>=1.0",
         "packaging",
         "pyarrow",
         "requests",

--- a/wmfdata/utils.py
+++ b/wmfdata/utils.py
@@ -37,7 +37,7 @@ def pd_display_all(df):
     with pd.option_context(
         "display.max_rows", None,
         "display.max_columns", None,
-        "display.max_colwidth", -1,
+        "display.max_colwidth", None
     ):
         display(df)
 


### PR DESCRIPTION
In Pandas 2.0, display.max_colwidth can no longer be disabled by setting it to `-1`. `None` must be used instead.