### PR TITLE
T341589: Improve formatting of df_to_remarkup / add kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,9 @@ Other features include:
 For an introduction to using Wmfdata, see [the quickstart notebook](docs/quickstart.ipynb).
 
 ## Installation and upgrading
-Wmfdata comes preinstalled in the Conda environments used on the analytics clients.
+Wmfdata comes preinstalled in the [Conda environments used on the analytics clients](https://wikitech.wikimedia.org/wiki/Data_Engineering/Systems/Conda).
 
-The command to upgrade to the latest version depends on whether you are using an `anaconda-wmf` or `conda-analytics` environment. To find out which you're using, consult [the Conda page on Wikitech](https://wikitech.wikimedia.org/wiki/Analytics/Systems/Conda).
-
-In an `anaconda-wmf` environment, use:
-```
-pip install --upgrade git+https://github.com/wikimedia/wmfdata-python.git@release --ignore-installed
-```
-
-In a `conda-analytics` environment, use:
+To upgrade to a newer version, use:
 ```
 pip install --upgrade git+https://github.com/wikimedia/wmfdata-python.git@release
 ```

--- a/wmfdata/utils.py
+++ b/wmfdata/utils.py
@@ -52,10 +52,10 @@ def insert_code_toggle():
     display(HTML("""
     <form action="javascript:code_toggle()">
         <input
-          id="code_toggle"
-          type="submit"
-          value="Hide code"
-          style="font-size: 1.4em"
+            id="code_toggle"
+            type="submit"
+            value="Hide code"
+            style="font-size: 1.4em"
         >
     </form>
 
@@ -86,33 +86,21 @@ def mediawiki_dt(dt):
     """
     return dt.strftime("%Y%m%d%H%M%S")
 
-def df_to_remarkup(df):
+def df_to_remarkup(df, **kwargs):
     """
     Prints a Pandas dataframe as a Remarkup table suitable for pasting into
     Phabricator.
 
-    Best used via the `pipe` method, as in `my_dataframe.pipe(df_to_remarkup)`.
+    Note that among many kwargs the following are useful for editing the output:
+        index (bool): passing `False` removes the dataframe index (default is `True`)
+            Ex: `df_to_remarkup(df, index=False)`
 
-    Note that indexes are not currently supported, so if your index contains
-    something important, you should use call `my_dataframe.reset_index` first.
+        floatfmt (str): the decimal place to round the outputs to
+            Ex: `df_to_remarkup(df, floatfmt=".1f")` to round to the first decimal place
+
+    See the options for pandas.DataFrame.to_markdown and the Python package tabulate for other kwargs.
     """
-    # To-do: allow printing indexes
-    col_count = len(df.columns)
-    header_sep = "| ----- " * col_count
-    psv_table = (
-        df
-        .to_csv(sep="|", index=False)
-        # Pad every pipe with spaces so the markup is easier to read
-        .replace("|", " | ")
-    )
-
-    # Add a pipe to the start of every line, before adding the header separator
-    # so it doesn't get a double first pipe
-    remarkup_table = re.sub(r"^([^|])", r"| \1", psv_table, flags=re.MULTILINE)
-    # Make the first row a header
-    remarkup_table = remarkup_table.replace("\n", "\n" + header_sep + "\n", 1)
-
-    print(remarkup_table)
+    print(df.to_markdown(tablefmt="pipe", **kwargs).replace(":", "-"))
 
 def check_remote_version(source_url, local_version):
     r = requests.get(source_url + "/raw/release/wmfdata/metadata.py", timeout=1)
@@ -140,7 +128,7 @@ def check_kerberos_auth():
         )
     elif klist != 0:
         raise OSError(
-          "There was an unknown issue checking your Kerberos credentials."
+            "There was an unknown issue checking your Kerberos credentials."
         )
 
 def ensure_list(str_or_list):

--- a/wmfdata/utils.py
+++ b/wmfdata/utils.py
@@ -52,10 +52,10 @@ def insert_code_toggle():
     display(HTML("""
     <form action="javascript:code_toggle()">
         <input
-            id="code_toggle"
-            type="submit"
-            value="Hide code"
-            style="font-size: 1.4em"
+          id="code_toggle"
+          type="submit"
+          value="Hide code"
+          style="font-size: 1.4em"
         >
     </form>
 
@@ -88,15 +88,14 @@ def mediawiki_dt(dt):
 
 def df_to_remarkup(df, **kwargs):
     """
-    Prints a Pandas dataframe as a Remarkup table suitable for pasting into
-    Phabricator.
+    Prints a Pandas dataframe as a Remarkup table suitable for pasting into Phabricator.
 
     Note that among many kwargs the following are useful for editing the output:
         index (bool): passing `False` removes the dataframe index (default is `True`)
             Ex: `df_to_remarkup(df, index=False)`
 
-        floatfmt (str): the decimal place to round the outputs to
-            Ex: `df_to_remarkup(df, floatfmt=".1f")` to round to the first decimal place
+        floatfmt (str or list(str)): the decimal place to round the outputs to
+            Ex: `df_to_remarkup(df, floatfmt=(".0f", ".1f"))` (round off first column and to first decimal in second)
 
     See the options for pandas.DataFrame.to_markdown and the Python package tabulate for other kwargs.
     """
@@ -128,7 +127,7 @@ def check_kerberos_auth():
         )
     elif klist != 0:
         raise OSError(
-            "There was an unknown issue checking your Kerberos credentials."
+          "There was an unknown issue checking your Kerberos credentials."
         )
 
 def ensure_list(str_or_list):

--- a/wmfdata_tests/tests.py
+++ b/wmfdata_tests/tests.py
@@ -221,7 +221,7 @@ def test_df_to_remarkup():
     df_to_remarkup(df_requests_dummy, index=False, floatfmt=(".0f", ".0f", ".1f"))
     output_str_2 = captured_output_2.getvalue().split("\n")[:-1]
 
-    # We have `index=False`, so the first value of row 0 should be the `http_status` value `200``.
+    # We have `index=False`, so the first value of row 0 should be the `http_status` value `200`.
     # It should also be `200` and not `200.0` as this column has been formatted to `.0f` using floatfmt.
     assert output_str_2[2].split("|")[1].strip() == "200"
     # floatfmt was used to round the third column to the first decimal place, so this percent should be `2.0`.

--- a/wmfdata_tests/tests.py
+++ b/wmfdata_tests/tests.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
 import argparse
+import io
 import os
 from pathlib import Path
 import re
+import sys
 
 import pandas as pd
 import wmfdata as wmf
 
 this_directory = str(Path(__file__).parent.resolve())
 
-# To do: This way of specifying the Hive database makes it impossible to 
+# To do: This way of specifying the Hive database makes it impossible to
 # import this as a module. It would be better to have the test functions
 # take the database as an argument, and look for and pass a command line
 # argument only if it's being run as a script.
@@ -24,7 +26,7 @@ parser.add_argument(
 args = parser.parse_args()
 hive_db = args.hive_database
 
-# Theoretically, the passed database could be used to inject SQL (e.g. passing 
+# Theoretically, the passed database could be used to inject SQL (e.g. passing
 # 'wmf.webrequest --' in an attempt to drop webrequest). Practically, it
 # cannot be since analytics cluster users are all trusted and, unless they are
 # data engineers, only have write access to their own and explicitly shared
@@ -46,7 +48,7 @@ def assert_dataframes_match(df1, df2):
     assert df1.index.equals(df2.index)
     assert df1.columns.equals(df2.columns)
 
-def set_up_table_1(): 
+def set_up_table_1():
     spark = wmf.spark.create_session(type="local", app_name="wmfdata-test")
     spark_df = spark.read.load(f"file://{this_directory}/test_data_1.parquet")
     spark_df.write.mode("overwrite").saveAsTable(f"{hive_db}.wmfdata_test_1")
@@ -60,9 +62,9 @@ def set_up_mariadb_table():
     CREATE_TABLE_SQL = """
         CREATE TABLE wmfdata_test (
             month VARCHAR(255),
-            wiki VARCHAR(255), 
+            wiki VARCHAR(255),
             user_id BIGINT,
-            user_name VARCHAR(255), 
+            user_name VARCHAR(255),
             edits BIGINT,
             content_edits BIGINT,
             user_registration VARCHAR(255)
@@ -71,16 +73,16 @@ def set_up_mariadb_table():
 
     INSERT_RECORDS_SQL = f"""
         INSERT INTO
-        wmfdata_test 
+        wmfdata_test
         VALUES
         {test_data_1_records}
     """
 
     wmf.mariadb.run(
-        [CREATE_TABLE_SQL, INSERT_RECORDS_SQL], 
+        [CREATE_TABLE_SQL, INSERT_RECORDS_SQL],
         dbs=["staging"]
     )
-    
+
 def clean_tables():
     wmf.hive.run([
       f"DROP TABLE IF EXISTS {hive_db}.wmfdata_test_1",
@@ -153,12 +155,12 @@ def test_read_via_mariadb():
         """
         SELECT *
         FROM wmfdata_test
-        """, 
+        """,
         "staging"
     )
 
     assert_dataframes_match(TEST_DATA_1, test_data_1_via_mariadb)
-    
+
     log_test_passed("Read via MariaDB")
 
 def test_silent_command_via_MariaDB():
@@ -193,6 +195,39 @@ def test_sql_tuple():
 
     log_test_passed("utils.sql_tuple unit test")
 
+def test_df_to_remarkup():
+    # Test to see that we can remove indexes and format numbers in df_to_remarkup outputs.
+    df_requests_dummy = pd.DataFrame(
+        data={
+            "http_status": [200, 404, 305],
+            "total_requests": [975, 20, 2],
+            "percent_of_total": [97.5, 2, 0.5]
+        }
+    )
+
+    # Capture the output of df_to_remarkup print statements and test their values.
+    captured_output_1 = io.StringIO()
+    sys.stdout = captured_output_1
+    df_to_remarkup(df_requests_dummy)
+    output_str_1 = captured_output_1.getvalue().split("\n")[:-1]
+
+    # We have the default `index=True`, so the first value of row 0 should be the index value `0`.
+    assert output_str_1[2].split("|")[1].strip() == "0"
+    # We are not using floatfmt by default, so the percent in the second row should be the integer `2`.
+    assert output_str_1[3].split("|")[-2].strip() == "2"
+
+    captured_output_2 = io.StringIO()
+    sys.stdout = captured_output_2
+    df_to_remarkup(df_requests_dummy, index=False, floatfmt=(".0f", ".0f", ".1f"))
+    output_str_2 = captured_output_2.getvalue().split("\n")[:-1]
+
+    # We have `index=False`, so the first value of row 0 should be the `http_status` value `200``.
+    # It should also be `200` and not `200.0` as this column has been formatted to `.0f` using floatfmt.
+    assert output_str_2[2].split("|")[1].strip() == "200"
+    # floatfmt was used to round the third column to the first decimal place, so this percent should be `2.0`.
+    assert output_str_2[3].split("|")[-2].strip() == "2.0"
+
+    log_test_passed("utils.df_to_remarkup unit tests")
 
 def main():
     clean_tables()
@@ -208,8 +243,8 @@ def main():
     test_read_via_mariadb()
     test_silent_command_via_MariaDB()
     test_load_csv()
-
     test_sql_tuple()
+    test_df_to_remarkup()
 
     clean_tables()
 


### PR DESCRIPTION
## Changes

- `df_to_remarkup` now makes use of `pandas.DataFrame.to_markdown` to dramatically simplify the code
  - Adding `.replace(":", "-")` to the result is the only required change for Phabricator formatting
- This change also allows for kwargs for `pandas.DataFrame.to_markdown` and the Python package `tabulate` to be passed for formatting the results (including row numbers and formatting float columns)
- The doc string for the function has been changed to reflect the new usage and includes examples for the `index` and `floatfmt` kwargs
- Minor changes to indentation in `utils.py` in places where two spaces were being used instead of four

## Notes

- Please see [T341589](https://phabricator.wikimedia.org/T341589) for the discussion :)