### PR TITLE
Update the ca_bundle used for presto connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+* The CA bundle that is used for establishing a TLS connection with presto has been updated to the new combined bundle. This supports certificates signed by the
+legacy Puppet 5 built-in certificate authority, as well as the newer certificates signed by the WMF PKI system.
+
 # 2.0.1 (18 September 2023)
 * Urllib3 is now pinned below 2.0 to avoid errors when querying Presto ([T345309](https://phabricator.wikimedia.org/T345309)).
 * Matplotlib is no longer specified as a dependency, since the `charting` module was removed in 2.0.

--- a/wmfdata/presto.py
+++ b/wmfdata/presto.py
@@ -36,7 +36,7 @@ def run(commands, catalog="analytics_hive"):
         config="/etc/krb5.conf",
         service_name="presto",
         principal=f"{USER_NAME}@WIKIMEDIA",
-        ca_bundle="/etc/ssl/certs/Puppet_Internal_CA.pem"
+        ca_bundle="/etc/ssl/certs/wmf-ca-certificates.crt"
     )
 
     connection = prestodb.dbapi.connect(


### PR DESCRIPTION
Until now we have been using Puppet certificates to encrypt connections to Presto. We will shortly be using certificates that are generated by the PKI system instead.

As such, wmfdata-python needs to know about our root CA as well as the puppet CA. This change enables that by using a new, combined CA bundle.

Once this change in in place, we can safely update the presto certificates and wmfdata-python will continue to work.

Bug: T345482