### PR TITLE
Retry presto.run with the alternative hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# next
+* Prepare for the switching of the kerberos principal and DNS name of the presto coordinator. In order to avoid a breaking change when we
+  make the switch, this change will cause prestodb.run to try to connect using the old name, but if that fails it will reconnect with the new name.
 # 2.2.0 (5 December 2023)
 * The CA bundle that is used for establishing a TLS connection with presto has been updated to the new combined bundle. This supports certificates signed by the
 legacy Puppet 5 built-in certificate authority, as well as the newer certificates signed by the WMF PKI system.


### PR DESCRIPTION
We are preparing to switch the kerberos principal used for the presto coordinator from an-coord1001.eqiad.wmnet to
analytics-presto.eqiad.wmnet

The DNS hostname will also change and will be a CNAME alias for one of several coorinator candidates.

In order to avoid a breaking change in wmfdata-python, we will need to be able to support both of these hiostnames and principals for a short time. In order to do this we are adding a try/except mechanism to the presto.run method. If it fails to connect to the old name, it will try the new name.

The old name will be removed in due course, once the switch has been made.

Bug: T345482