### PR TITLE
Allow wmfdata to use a DNS CNAME for the presto coordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # next
 * Use a DNS lookup to ascertain which hostname is referenced by the analytics-presto.eqiad.wmnet CNAME and use this information when authenticatin client connections. This will facilitate migrating the coordinator role to new hosts ([T345482](https://phabricator.wikimedia.org/T345482)).
+* Remove the code that disabled hostname mismatch warnings in urllib3, as it is no longer required.
 
 # 2.2.0 (5 December 2023)
 * The CA bundle that is used for establishing a TLS connection with presto has been updated to the new combined bundle. This supports certificates signed by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# next
+* Use a DNS lookup to ascertain which hostname is referenced by the analytics-presto.eqiad.wmnet CNAME and use this information when authenticatin client connections. This will facilitate migrating the coordinator role to new hosts ([T345482](https://phabricator.wikimedia.org/T345482)).
+
 # 2.2.0 (5 December 2023)
 * The CA bundle that is used for establishing a TLS connection with presto has been updated to the new combined bundle. This supports certificates signed by the
 legacy Puppet 5 built-in certificate authority, as well as the newer certificates signed by the WMF PKI system.

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "Wikimedia data"
     ),
     install_requires=[
+        "dnspython",
         "IPython",
         "findspark",
         # This is the latest version which supports MariaDB Connector/C 3.1.16,

--- a/wmfdata/presto.py
+++ b/wmfdata/presto.py
@@ -13,12 +13,6 @@ from wmfdata.utils import (
 
 PRESTO_HOST = "analytics-presto.eqiad.wmnet"
 
-# Disable a warning issued by urllib3 because the certificate for an-coord1001.eqiad.wmnet
-# does not specify the hostname in the subjectAltName field (T158757)
-SubjectAltNameWarning = urllib3.exceptions.SubjectAltNameWarning
-urllib3.disable_warnings(SubjectAltNameWarning)
-
-
 def resolve_presto_host_cname():
     dns_answers = dns.resolver.resolve(PRESTO_HOST, "CNAME")
     if len(dns_answers.rrset) == 0:

--- a/wmfdata/presto.py
+++ b/wmfdata/presto.py
@@ -1,6 +1,7 @@
 import os
 import warnings
 
+import dns.resolver
 import pandas as pd
 import prestodb
 from requests.packages import urllib3
@@ -10,10 +11,20 @@ from wmfdata.utils import (
     ensure_list
 )
 
+PRESTO_HOST = "analytics-presto.eqiad.wmnet"
+
 # Disable a warning issued by urllib3 because the certificate for an-coord1001.eqiad.wmnet
 # does not specify the hostname in the subjectAltName field (T158757)
 SubjectAltNameWarning = urllib3.exceptions.SubjectAltNameWarning
 urllib3.disable_warnings(SubjectAltNameWarning)
+
+
+def resolve_presto_host_cname():
+    dns_answers = dns.resolver.resolve(PRESTO_HOST, "CNAME")
+    if len(dns_answers.rrset) == 0:
+        return None
+    return dns_answers.rrset[0].to_text().rstrip('.')
+
 
 def run(commands, catalog="analytics_hive"):
     """
@@ -30,18 +41,20 @@ def run(commands, catalog="analytics_hive"):
     """
     commands = ensure_list(commands)
     check_kerberos_auth()
+    hostname_override = resolve_presto_host_cname()
 
     USER_NAME = os.getenv("USER")
     PRESTO_AUTH = prestodb.auth.KerberosAuthentication(
         config="/etc/krb5.conf",
         service_name="presto",
         principal=f"{USER_NAME}@WIKIMEDIA",
-        ca_bundle="/etc/ssl/certs/wmf-ca-certificates.crt"
+        ca_bundle="/etc/ssl/certs/wmf-ca-certificates.crt",
+        hostname_override=hostname_override
     )
 
     connection = prestodb.dbapi.connect(
         catalog=catalog,
-        host="an-coord1001.eqiad.wmnet",
+        host=PRESTO_HOST,
         port=8281,
         http_scheme="https",
         user=USER_NAME,


### PR DESCRIPTION
We wish to use a CNAME for analytics-presto.eqiad.wmnet in order to make
it possible to migrate the presto coordinator role from one host to
another.