### PR TITLE
Unpin Urllib3 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,7 @@ setup(
         "requests_kerberos",
         "presto-python-client",
         "pyhive[hive]",
-        # Urllib3 2.0 removes support for finding the host name in the 
-        # key certificate's commonName field during TLS authentication,
-        # which makes it impossible for presto-python-client to connect 
-        # to our Presto coordinator
-        # https://phabricator.wikimedia.org/T345309
-        "urllib3<2"
+        "urllib3"
     ],
     packages=find_packages(),
     python_requires=">=3",


### PR DESCRIPTION
Now that the Presto infrastructure has been upgraded to use TLS certificates with the subjectAltName filled out, we no longer need to pin Urllib3 below v2.0.

Bug: T345483