### PR TITLE
Suppress Pandas UserWarning during mariadb.run and hive.run

### DIFF
--- a/wmfdata/hive.py
+++ b/wmfdata/hive.py
@@ -42,11 +42,15 @@ def run(commands):
     with hive.connect(**connect_kwargs) as conn:
         for command in commands:
             try:
-                # this will work when the command is a SQL query
-                # so the last query in `commands` will return its results
                 with warnings.catch_warnings():
+                    # Pandas officially does not support using arbitrary DB-API 2.0 drivers
+                    # like PyHive. However, in reality, it works fine, so we just suppress the
+                    # warning. See T324135 for more details.
                     message="pandas only supports SQLAlchemy connectable"
                     warnings.filterwarnings("ignore", category=UserWarning, message=message)
+
+                    # this will work when the command is a SQL query
+                    # so the last query in `commands` will return its results
                     response = pd.read_sql(command, conn)
             except TypeError:
                 # The weird thing here is the command actually runs,

--- a/wmfdata/hive.py
+++ b/wmfdata/hive.py
@@ -3,6 +3,7 @@ import pwd
 import tempfile
 import pandas as pd
 import subprocess
+import warnings
 
 from pyhive import hive
 from shutil import copyfileobj
@@ -43,7 +44,10 @@ def run(commands):
             try:
                 # this will work when the command is a SQL query
                 # so the last query in `commands` will return its results
-                response = pd.read_sql(command, conn)
+                with warnings.catch_warnings():
+                    message="pandas only supports SQLAlchemy connectable"
+                    warnings.filterwarnings("ignore", category=UserWarning, message=message)
+                    response = pd.read_sql(command, conn)
             except TypeError:
                 # The weird thing here is the command actually runs,
                 # Pandas just has trouble when trying to read the result

--- a/wmfdata/mariadb.py
+++ b/wmfdata/mariadb.py
@@ -141,6 +141,9 @@ def run(
         for command in commands:
             try:
                 with warnings.catch_warnings():
+                    # Pandas officially does not support using arbitrary DB-API 2.0 drivers
+                    # like MariaDB Connector/Python. However, in reality, it works fine, so
+                    # we just suppress the warning. See T324135 for more details.
                     message="pandas only supports SQLAlchemy connectable"
                     warnings.filterwarnings("ignore", category=UserWarning, message=message)
                     result = pd.read_sql_query(

--- a/wmfdata/mariadb.py
+++ b/wmfdata/mariadb.py
@@ -2,6 +2,7 @@ import atexit
 import getpass
 import grp
 import subprocess
+import warnings
 
 import mariadb
 from mariadb.constants import FIELD_TYPE
@@ -139,12 +140,15 @@ def run(
         # Pandas's complex SQL machinery.
         for command in commands:
             try:
-                result = pd.read_sql_query(
-                    command,
-                    connection,
-                    index_col=index_col,
-                    parse_dates=date_col
-                )
+                with warnings.catch_warnings():
+                    message="pandas only supports SQLAlchemy connectable"
+                    warnings.filterwarnings("ignore", category=UserWarning, message=message)
+                    result = pd.read_sql_query(
+                        command,
+                        connection,
+                        index_col=index_col,
+                        parse_dates=date_col
+                    )
             # pandas will encounter a TypeError with DDL (e.g. CREATE TABLE) or
             # DML (e.g. INSERT) statements
             except TypeError:


### PR DESCRIPTION
Filters UserWarnings with pandas SQLAlchemy message

Note that I wasn't able to test directly as I couldn't successfully install my own version of this library to my environment on a stathost. But this filter approach is what I used in my own code to wrap the provided `run()` methods

Bug: [T324135](https://phabricator.wikimedia.org/T324135)